### PR TITLE
add feed meta-tag to page heads

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/icon/icon_16x16.png' | absolute_url }}">
 <link rel="shortcut icon" href="{{ '/assets/icon/favicon.ico' | absolute_url }}">
 <meta name="theme-color" content="#ffffff">
+{% feed_meta %}
 
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}" />
 <noscript><link rel="stylesheet" href="{{ '/assets/css/noscript.css' | absolute_url }}" /></noscript>


### PR DESCRIPTION
This PR adds a meta-tag to page heads, so that browsers display a feed symbol (if running appropriate plugins). See the [jekyll-feed docs](https://github.com/jekyll/jekyll-feed#meta-tags)